### PR TITLE
Add versioning middleware to handle offline versioning checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ obj
 .env.local
 .env.*.local
 chunk-sizes.html
-website/.dev.vars
 
 # Log files
 npm-debug.log*

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -6,6 +6,7 @@
 dist
 .wrangler
 public/search-index.json
+public/version.json
 stats.html
 .data
 
@@ -35,3 +36,4 @@ logs
 .env
 .env.*
 !.env.example
+.dev.vars

--- a/website/layouts/default.vue
+++ b/website/layouts/default.vue
@@ -20,6 +20,14 @@
 <script setup lang="ts">
 import LogoHead from "~icons/custom/head";
 
+const searchClient = useSearch();
+/*
+  Kick off a background download of the search index if it hasn't been downloaded yet.
+  Periodic checks are done after page load within the versioning middleware.
+  This is also needed to pull in the data from localStorage on a fresh page load.
+*/
+searchClient.ensureIndex();
+
 const route = useRoute();
 
 const initialQuery = route.query.search && typeof route.query.search === "string" ? route.query.search : null;

--- a/website/layouts/default.vue
+++ b/website/layouts/default.vue
@@ -20,11 +20,6 @@
 <script setup lang="ts">
 import LogoHead from "~icons/custom/head";
 
-const searchClient = useSearch();
-// Ensure the search index exists on each page load,
-// so that if it is missing it can trigger a background download
-searchClient.ensureIndex();
-
 const route = useRoute();
 
 const initialQuery = route.query.search && typeof route.query.search === "string" ? route.query.search : null;

--- a/website/middleware/versioning.global.ts
+++ b/website/middleware/versioning.global.ts
@@ -1,0 +1,100 @@
+import type { Version } from "~/types/version";
+
+let searchIndexDownload: Promise<void> | null = null;
+let isBuildStale = false;
+
+const buildVersionStorageKey = "build-version";
+const searchIndexHashStorageKey = "search-index-hash";
+const lastCheckTimeStorageKey = "last-version-check";
+
+/**
+ * Periodically check for an outdated client build or search index.
+ * This prevents clients that were downloaded and cached a while ago from persisting index.html or an old search index,
+ * which would potentially lead to errors or stale content.
+
+ * This is done seamlessly in the background, either doing a full page load during a navigation
+ * or downloading and swapping in the new search index in the background
+ */
+export default defineNuxtRouteMiddleware((to) => {
+  if (!process.client) {
+    return;
+  }
+
+  const lastVersionCheckMs = Number(localStorage.getItem(lastCheckTimeStorageKey));
+
+  const fiveMinutesInMs = 1000 * 60 * 5;
+  if (lastVersionCheckMs && lastVersionCheckMs > Date.now() - fiveMinutesInMs) {
+    return;
+  }
+
+  if (isBuildStale) {
+    isBuildStale = false;
+    // Do a full page refresh to reload index.html and any changed scripts/styles during an existing user navigation
+    reloadNuxtApp({
+      path: to.path,
+    });
+  }
+
+  // Check for newer versions in the background to avoid delaying navigation
+  getLatestVersionNumbers().then((version) => {
+    if (!version) {
+      return;
+    }
+
+    const isSearchIndexStale = checkForStaleSearchIndex(version.searchIndex);
+    if (isSearchIndexStale) {
+      /*
+        Trigger a background download of the latest search index,
+        skipping if there are any already active requests to prevent duplicate requests
+      */
+      if (!searchIndexDownload) {
+        searchIndexDownload = useSearch()
+          .refreshIndex()
+          .finally(() => {
+            localStorage.setItem(searchIndexHashStorageKey, version.searchIndex);
+            searchIndexDownload = null;
+          });
+      }
+    }
+
+    /*
+      If the search index is downloading we don't want to trigger a full page load and cancel a pending request.
+      It can always happen after the next navigation, an old build won't immediately affect the user experience.
+    */
+    if (!searchIndexDownload && checkForStaleBuild(version.build)) {
+      localStorage.setItem("build-version", version.build);
+      isBuildStale = true;
+    }
+  });
+
+  localStorage.setItem(lastCheckTimeStorageKey, Date.now().toString());
+});
+
+async function getLatestVersionNumbers(): Promise<Version | null> {
+  const { data: data } = await useFetch<Version>("/version.json");
+  return data.value;
+}
+
+function checkForStaleBuild(latestVersion: string) {
+  const currentVersion = localStorage.getItem(buildVersionStorageKey);
+  // If the version is not set then we can assume it is a fresh page load and the build will be up to date
+  if (!currentVersion) {
+    localStorage.setItem(buildVersionStorageKey, latestVersion);
+    return false;
+  }
+
+  if (currentVersion === latestVersion) {
+    return false;
+  }
+
+  return true;
+}
+
+function checkForStaleSearchIndex(latestVersion: string) {
+  const currentVersion = localStorage.getItem(searchIndexHashStorageKey);
+  if (currentVersion === latestVersion) {
+    return false;
+  }
+
+  return true;
+}

--- a/website/modules/recipe/index.ts
+++ b/website/modules/recipe/index.ts
@@ -6,9 +6,14 @@ import { searchIndexSettings, type SearchIndexIndexed } from "../../types/search
 import * as fs from "fs/promises";
 import * as crypto from "crypto";
 import type { Nuxt } from "nuxt/schema";
+import type { Version } from "~/types/version";
 
 export default defineNuxtModule({
   async setup(options, nuxt) {
+    if (!process.env.CF_PAGES_COMMIT_SHA) {
+      throw new Error("CF_PAGES_COMMIT_SHA environment variable is undefined. A build ID cannot be determined.");
+    }
+
     const recipes = await getAllRecipes();
 
     const searchIndex = generateRecipeSearchIndex(recipes);
@@ -70,9 +75,14 @@ async function saveRecipeSearchIndex(index: string, nuxt: Nuxt) {
   const hash = crypto.createHash("md5").update(index).digest("hex");
   console.log("Generated search index hash:", hash);
 
+  const currentVersion: Version = {
+    build: process.env.CF_PAGES_COMMIT_SHA!,
+    searchIndex: hash,
+  };
+
   /*
-  Store the hash in the runtimeConfig instead of appConfig
-  to avoid baking it into the JS and causing cascading cache invalidation
+    Store the current versions of assets in /public to allow the client
+    to periodically check for newer content
   */
-  nuxt.options.runtimeConfig.public.searchIndexHash = hash;
+  await fs.writeFile(`${publicFolderPath}/version.json`, JSON.stringify(currentVersion), "utf8");
 }

--- a/website/pages/index.vue
+++ b/website/pages/index.vue
@@ -130,11 +130,6 @@ useServerSeoMeta({
 useHead({
   title: content?.title,
 });
-
-const headerIcon = {
-  name: "gravity-ui:circle-chevron-right",
-  size: "32",
-};
 </script>
 
 <style lang="scss" scoped>

--- a/website/types/version.ts
+++ b/website/types/version.ts
@@ -1,0 +1,4 @@
+export type Version = {
+  build: string;
+  searchIndex: string;
+};


### PR DESCRIPTION
This avoids issues with the client downloading and caching the latest version of the website, and then leaving the tab open indefinitely. Returning to the tab and navigating around would still request the old js and css files, and not get the latest version of the SPA since the index.html file is also hashed.

With this change the client will periodically check for the current version of the app in the background, triggered on user navigation. If the client is out of date, a page refresh will occur during the next navigation, or the search index downloaded in the background, depending on what was out of date.