### PR TITLE
Fix image cloudflare caching

### DIFF
--- a/website/app/components/BlurrableImage.vue
+++ b/website/app/components/BlurrableImage.vue
@@ -48,15 +48,6 @@ const props = withDefaults(
 
 const fullSizeImageRef = useTemplateRef("fullSizeImageRef");
 
-const imageBuilder = useImage();
-
-const src = imageBuilder.buildRelativeUrl({
-  imageId: props.img.id,
-  modifyDate: props.img.modifyDate,
-  aspectRatio: props.aspectRatio,
-  purpose: props.purpose,
-});
-
 onMounted(() => {
   if (props.img.metadata?.base64Url && fullSizeImageRef.value?.img) {
     // If the image is already complete when mounting then don't show the animation. This likely means the image was already in the browser cache.

--- a/website/app/components/VImg.vue
+++ b/website/app/components/VImg.vue
@@ -3,7 +3,7 @@
     ref="imgRef"
     :src="src"
     :alt="img.title"
-    :width="props.img.width"
+    :width="img.width"
     :height="adjustedHeight"
     :loading="lazy ? 'lazy' : undefined"
   />
@@ -30,7 +30,8 @@ const src =
   props.thumbnail && props.img.metadata?.base64Url
     ? props.img.metadata.base64Url
     : image.buildRelativeUrl({
-        imageId: props.img.id,
+        id: props.img.id,
+        fileName: props.img.fileName,
         modifyDate: props.img.modifyDate,
         purpose: props.purpose,
         aspectRatio: props.aspectRatio,

--- a/website/app/composables/useImage.ts
+++ b/website/app/composables/useImage.ts
@@ -1,3 +1,5 @@
+import { imageFileExtension } from "~~/shared/constants/images";
+
 export function useImage() {
   function getAspectRatio(aspectRatio: AspectRatio): { x: number; y: number } {
     switch (aspectRatio) {
@@ -14,43 +16,31 @@ export function useImage() {
     }
   }
 
-  function buildRelativeUrl({
-    imageId,
-    modifyDate,
-    purpose,
-    aspectRatio,
-  }: {
-    imageId: string;
+  type ImageUrlParams = {
+    id: string;
+    fileName: string;
     modifyDate: string;
     purpose: ImagePurpose;
     aspectRatio: AspectRatio;
-  }) {
+  };
+
+  function buildRelativeUrl(image: ImageUrlParams) {
     const params = new URLSearchParams({
-      modifyDate: modifyDate,
-      purpose: purpose,
-      aspectRatio: aspectRatio,
+      modifyDate: image.modifyDate,
+      purpose: image.purpose,
+      aspectRatio: image.aspectRatio,
     });
 
-    return `/api/images/${imageId}?${params}`;
+    return `/api/images/${image.id}/${image.fileName}.${imageFileExtension}?${params}`;
   }
 
-  function buildExternalUrl({
-    imageId,
-    modifyDate,
-    purpose,
-    aspectRatio,
-  }: {
-    imageId: string;
-    modifyDate: string;
-    purpose: ImagePurpose;
-    aspectRatio: AspectRatio;
-  }) {
+  function buildExternalUrl(image: ImageUrlParams) {
     const appConfig = useAppConfig();
     if (!appConfig.externalBaseUrl) {
       throw new Error("NUXT_PUBLIC_SITE_URL environment variable is not defined");
     }
 
-    const relativeUrl = buildRelativeUrl({ imageId, modifyDate, purpose, aspectRatio });
+    const relativeUrl = buildRelativeUrl(image);
 
     return `${appConfig.externalBaseUrl}${relativeUrl}`;
   }

--- a/website/app/composables/useSearch.ts
+++ b/website/app/composables/useSearch.ts
@@ -3,7 +3,7 @@ import MiniSearch, { type SearchResult } from "minisearch";
 // Store these outside the function in the global scope for re-use
 const miniSearch = ref<MiniSearch<SearchIndexSearchFields>>();
 
-export interface RecipeSearchResult extends SearchResult, SearchIndexStoredFields {}
+export type RecipeSearchResult = SearchResult & SearchIndexRecipe;
 
 export function useSearch() {
   async function ensureIndex() {

--- a/website/app/pages/recipes/[slug].vue
+++ b/website/app/pages/recipes/[slug].vue
@@ -179,7 +179,8 @@ if (import.meta.server) {
     description: recipe.value.descriptionPlainText,
     ogDescription: recipe.value.descriptionSnippet,
     ogImage: image.buildExternalUrl({
-      imageId: recipe.value.coverImage.id,
+      id: recipe.value.coverImage.id,
+      fileName: recipe.value.coverImage.fileName,
       modifyDate: recipe.value.coverImage.modifyDate,
       purpose: "cover",
       aspectRatio: "square",
@@ -192,7 +193,8 @@ if (import.meta.server) {
     name: recipe.value.title,
     description: recipe.value.descriptionSnippet,
     image: image.buildExternalUrl({
-      imageId: recipe.value.coverImage.id,
+      id: recipe.value.coverImage.id,
+      fileName: recipe.value.coverImage.fileName,
       modifyDate: recipe.value.coverImage.modifyDate,
       purpose: "cover",
       aspectRatio: "square",

--- a/website/app/pages/recipes/index.vue
+++ b/website/app/pages/recipes/index.vue
@@ -3,7 +3,7 @@
     <h3>
       No recipes found for <b>{{ searchTerm }}</b>
     </h3>
-    <v-button size="large" @click="showAllRecipes">See all recipes</v-button>
+    <v-button size="large" @click="navigateTo('/recipes')">See all recipes</v-button>
   </div>
   <div v-else>
     <h2>
@@ -15,10 +15,13 @@
           v-for="(recipe, index) in recipes"
           :key="recipe.slug"
           :title="recipe.title"
-          :image="{ ...recipe.coverImage, title: `Picture of ${recipe.title}` }"
+          :image="{
+            ...recipe.coverImage,
+            title: `Picture of ${recipe.title}`,
+          }"
           :link="`/recipes/${recipe.slug}`"
           :tag="recipe.featuredTag"
-          :duration="recipe.totalDuration"
+          :duration="recipe.totalDurationLabel"
           :lazy-load-image="index > 8"
         />
       </client-only>
@@ -38,7 +41,7 @@ const searchTerm = computed(() => {
 
 const searchClient = useSearch();
 
-const recipes = ref<RecipeSearchResult[]>([]);
+const recipes = ref<SearchIndexRecipe[]>([]);
 
 watch(
   () => route.query,
@@ -92,18 +95,17 @@ if (!contentResponse.data.value) {
 
 const content = contentResponse.data.value;
 
-useServerSeoMeta({
-  title: content.title,
-  ogTitle: content.title,
-  description: content.description,
-  ogDescription: content.openGraphDescription,
-});
 useHead({
   title: content.title,
 });
 
-async function showAllRecipes() {
-  await navigateTo("/recipes");
+if (import.meta.server) {
+  useSeoMeta({
+    title: content.title,
+    ogTitle: content.title,
+    description: content.description,
+    ogDescription: content.openGraphDescription,
+  });
 }
 </script>
 

--- a/website/functions/api/images/[[images]].ts
+++ b/website/functions/api/images/[[images]].ts
@@ -1,5 +1,6 @@
 import { useImage } from "../../../app/composables/useImage";
 import type { AspectRatio, ImagePurpose } from "../../../shared/types/image";
+import { imageFileExtension } from "../../../shared/constants/images";
 
 interface Env {
   BUCKET: R2Bucket;
@@ -11,7 +12,8 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
     throw new Error("Cloudinary API key environment variable not defined");
   }
 
-  const imageId = context.params.images;
+  const imageIdParams = context.params.images;
+  const imageId = typeof imageIdParams === "object" ? imageIdParams[0] : imageIdParams;
 
   const { searchParams } = new URL(context.request.url);
   const purpose = searchParams.get("purpose") as ImagePurpose;
@@ -37,7 +39,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
     }
   }
 
-  const fileName = `v1/recipes/${imageId}.avif`;
+  const fileName = `v1/recipes/${imageId}.${imageFileExtension}`;
   const signingParameters = `${transformations}${fileName}`;
 
   if (!transformations) {

--- a/website/modules/recipe/index.ts
+++ b/website/modules/recipe/index.ts
@@ -32,16 +32,26 @@ export default defineNuxtModule({
       const searchIndex = generateRecipeSearchIndex(recipes.map((r) => mapToSearchIndexRecipe(r)));
       await saveRecipeSearchIndex(searchIndex, nuxt);
     });
+
+    // Regenerate it each time in local dev
+    if (process.env.NODE_ENV === "development") {
+      logger.info("Refreshing search index for local development");
+
+      const recipes = (await import("~~/.nuxt/module/nuxt-prepare")).recipes;
+
+      const searchIndex = generateRecipeSearchIndex(recipes.map((r) => mapToSearchIndexRecipe(r)));
+      await saveRecipeSearchIndex(searchIndex, nuxt);
+    }
   },
 });
 
-function generateRecipeSearchIndex(recipes: SearchIndexRecipe[]) {
+const generateRecipeSearchIndex = (recipes: SearchIndexRecipe[]) => {
   logger.info("Generating recipe search index");
   const miniSearch = new MiniSearch<SearchIndexSearchFields>(searchIndexSettings);
 
   miniSearch.addAll(recipes);
   return JSON.stringify(miniSearch);
-}
+};
 
 async function saveRecipeSearchIndex(index: string, nuxt: Nuxt) {
   // Store recipe search index in public folder for client retrieval
@@ -72,6 +82,7 @@ const mapToSearchIndexRecipe = (serverRecipe: RecipePayload): SearchIndexRecipe 
     title: serverRecipe.title,
     coverImage: {
       id: serverRecipe.coverImage.id,
+      fileName: serverRecipe.coverImage.fileName,
       height: serverRecipe.coverImage.height,
       width: serverRecipe.coverImage.width,
       modifyDate: serverRecipe.coverImage.modifyDate,

--- a/website/server/utils/directusRecipeMapper.ts
+++ b/website/server/utils/directusRecipeMapper.ts
@@ -8,6 +8,7 @@ import type {
 } from "../../../common/types/serverRecipe";
 import extensions from "./extensions";
 import { throwExpression } from "../../shared/utils/error";
+import * as path from "path";
 
 export function useMapper() {
   return {
@@ -136,6 +137,10 @@ const mapImage = (serverImage: ServerImage): Image => {
     // Assert that all the required fields have been provided, for an image this should always be the case.
     id: serverImage.id ?? throwExpression("Image ID must be provided"),
     title: serverImage.title ?? throwExpression("Image title must be provided"),
+    fileName: serverImage.filename_download
+      ? // Remove the file extension, as it the file extension of the uploaded file, not the transformed one the client will receive
+        path.parse(serverImage.filename_download).name
+      : throwExpression("Image filename_download must be provided"),
     width: serverImage.width ?? throwExpression("Image width must be provided"),
     height: serverImage.height ?? throwExpression("Image height must be provided"),
     modifyDate: serverImage.modified_on ?? throwExpression("Image modified_on must be provided"),

--- a/website/server/utils/useDirectusApi.ts
+++ b/website/server/utils/useDirectusApi.ts
@@ -27,18 +27,9 @@ const authMiddleware: Middleware = {
 
 client.use(authMiddleware);
 
-const getImageFields = (path: string) => [
-  `${path}.id`,
-  `${path}.width`,
-  `${path}.height`,
-  `${path}.title`,
-  `${path}.modified_on`,
-  `${path}.metadata`,
-];
-
 const searchFields = [
   "*",
-  ...getImageFields("coverImage"),
+  "coverImage.*",
   "ingredientGroups.name",
   "ingredientGroups.ingredients.*",
   "instructionGroups.name",
@@ -48,7 +39,7 @@ const searchFields = [
   // Gets the inline_ingredient relationships from the instruction to the specified ingredient
   "instructionGroups.instructions.inline_ingredients.*",
   "instructionGroups.instructions.inline_ingredients.ingredient_id.*",
-  ...getImageFields("instructionGroups.instructions.image"),
+  "instructionGroups.instructions.image.*",
 ];
 
 export const useDirectusApi = () => {

--- a/website/shared/constants/images.ts
+++ b/website/shared/constants/images.ts
@@ -1,0 +1,2 @@
+/** The file extension used for website images */
+export const imageFileExtension = "avif";

--- a/website/shared/types/recipe.ts
+++ b/website/shared/types/recipe.ts
@@ -75,6 +75,7 @@ export type SearchIndexRecipe = {
   title: string;
   coverImage: {
     id: string;
+    fileName: string;
     height: number;
     width: number;
     modifyDate: string;
@@ -106,12 +107,20 @@ export type Ingredient = {
 };
 
 export type Image = {
+  /** The ID of the image */
   id: string;
+  /** The image title or alt text */
   title: string;
+  /** The file name, excluding the file extension */
+  fileName: string;
+  /** The height in pixels of the image */
   height: number;
+  /** The width in pixels of the image */
   width: number;
+  /** The modify date of the image for cache busting purposes */
   modifyDate: string;
   metadata?: {
+    /** The base64 encoded thumbnail of this image */
     base64Url: string;
   };
 };

--- a/website/shared/utils/searchIndex.ts
+++ b/website/shared/utils/searchIndex.ts
@@ -12,27 +12,11 @@ const emptySearchIndexIndexedFields: SearchIndexSearchFields = {
 };
 const searchIndexIndexedFields = Object.keys(emptySearchIndexIndexedFields);
 
-export type SearchIndexStoredFields = {
-  title: string;
-  coverImage: {
-    id: string;
-    height: number;
-    width: number;
-    modifyDate: string;
-    // Assign to never so these properties are not accidentally included in the search index, as they are not needed and bloat the size of the client side index
-    title?: never;
-    metadata?: never;
-  };
-  slug: string;
-  tags: string[];
-  featuredTag?: string;
-  totalDuration?: string;
-};
-
-const emptySearchIndexStoredFields: SearchIndexStoredFields = {
+const emptySearchIndexStoredFields: SearchIndexRecipe = {
   title: "",
   coverImage: {
     id: "",
+    fileName: "",
     height: 0,
     width: 0,
     modifyDate: "",
@@ -40,7 +24,7 @@ const emptySearchIndexStoredFields: SearchIndexStoredFields = {
   slug: "",
   tags: [],
   featuredTag: "",
-  totalDuration: "",
+  totalDurationLabel: "",
 };
 const searchIndexStoredFields = Object.keys(emptySearchIndexStoredFields);
 


### PR DESCRIPTION
Add file name and file extension to images to indicate to cloudflare that these are images, which enables automatic caching. Image responses went from DYNAMIC to HIT https://developers.cloudflare.com/cache/concepts/cache-responses/

Using file names and extensions for image URLs may also improve SEO